### PR TITLE
TAX_16.1

### DIFF
--- a/TAX_16-1.sh
+++ b/TAX_16-1.sh
@@ -1,0 +1,5 @@
+mkdir project
+cd C:\Users\Afoop\bootcamp_projects\Michal_Pisula-kodilla_tester\build\libs
+del *.jar
+call gradlew build
+IF EXIST "C:\Users\Afoop\bootcamp_projects\Michal_Pisula-kodilla_tester\build\libs\*.jar" COPY "C:\Users\Afoop\bootcamp_projects\Michal_Pisula-kodilla_tester\build\libs\*.jar" "C:\Users\Afoop\project" ELSE echo Compilation error


### PR DESCRIPTION
    Usuń wszystkie pliki build/libs/*.jar.
    Wywołaj gradlew build.
    Jeżeli istnieje plik build/libs/*.jar, to skopiuj go do podkatalogu project.
    Jeżeli plik nie istnieje – wyświetl komunikat o błędzie kompilacji.